### PR TITLE
Add signal handling and fix restart

### DIFF
--- a/src/device_handler.py
+++ b/src/device_handler.py
@@ -53,20 +53,26 @@ class DeviceHandler:
     def start(self):
         """Start the handler by listening to the installed services of the firestore device."""
         logger.info("Device Handler started.")
+        for service in self.installed_services:
+            service.start()
+
         self.watch = self.device.collection("installed_services").on_snapshot(
             self._on_new_installed_service
         )
 
     def stop(self):
-        logger.info("Device Handler stopped.")
         """Stop the handler by stopping the listener."""
+        logger.info("Device Handler stopped.")
+        for service in self.installed_services:
+            service.stop()
+
         if self.watch is not None:
             self.watch.unsubscribe()
 
     def restart(self):
-        """Restart the handler. This function just calls to `start()` and `stop()`."""
-        self.start()
+        """Restart the handler. This function just calls to `stop()` and `start()`."""
         self.stop()
+        self.start()
 
     def set_as_updated(self, service: str):
         """Set the given installed service as updated by removing it from the updatable services."""

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import logging
+import signal
 
 from communication_module import CommunicationModule
 from default_firestore_client import DefaultFirestoreClient
@@ -10,6 +11,11 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)-8s - %(name)-16s - %(message)s", level=LOG_LEVEL
 )
 logger = logging.getLogger(__name__)
+
+def signal_handler(sig, frame):
+    comm_module.stop()
+    client.stop_client()
+    device_handler.stop()
 
 if __name__ == "__main__":
     comm_module = CommunicationModule(host="127.0.0.1", port=5555)
@@ -31,3 +37,7 @@ if __name__ == "__main__":
 
     device_handler = DeviceHandler(client.client, client.user_id, device_id)
     device_handler.start()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.pause()


### PR DESCRIPTION
Add signal handling:
- Pause the main thread.
- Handle what happens when the service is interrupted or terminated.
- Start/stop each installed service of the device handler.
- Fix restart function.